### PR TITLE
Add FuseSoC support

### DIFF
--- a/chacha.core
+++ b/chacha.core
@@ -19,3 +19,7 @@ files =
 file_type = verilogSource
 usage = sim
 
+[parameter DEBUG]
+datatype = int
+description = Enable debug printouts
+paramtype = vlogparam

--- a/chacha.core
+++ b/chacha.core
@@ -1,0 +1,21 @@
+CAPI=1
+
+[main]
+
+name = ::chacha:0
+description = Verilog 2001 implementation of the ChaCha stream cipher
+
+[fileset rtl]
+files =
+ src/rtl/chacha_qr.v
+ src/rtl/chacha_core.v
+ src/rtl/chacha.v
+file_type = verilogSource
+
+[fileset tb]
+files =
+ src/tb/tb_chacha_core.v
+ src/tb/tb_chacha.v
+file_type = verilogSource
+usage = sim
+

--- a/src/tb/tb_chacha.v
+++ b/src/tb/tb_chacha.v
@@ -40,7 +40,7 @@ module tb_chacha();
   //----------------------------------------------------------------
   // Internal constant and parameter definitions.
   //----------------------------------------------------------------
-  localparam DEBUG = 1;
+  parameter DEBUG = 1;
 
   localparam CLK_HALF_PERIOD = 1;
   localparam CLK_PERIOD = 2 * CLK_HALF_PERIOD;


### PR DESCRIPTION
Adding a FuseSoC .core file makes it easier to run with different simulator flows and integrate in other projects.

Use `fusesoc --cores-root=/path/to/repo sim --sim={icarus,modelsim,isim,xsim,rivierapro} --testbench={tb_chacha,tb_chacha_core} chacha`

To turn off the debug printouts, add `--DEBUG=0` at the end of the command line

Tested with Icarus and modelsim