### PR TITLE
Openlane support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,34 @@ jobs:
       - run: chmod +x openlane_runner.py
       - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
       - run: fusesoc run --target=sky130 $VLNV
+
+  sim-icarus:
+    runs-on: ubuntu-latest
+    env:
+      REPO : chacha
+      VLNV : secworks:crypto:chacha
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: chacha
+      - run: sudo apt install iverilog
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=tb_chacha $VLNV
+      - run: fusesoc run --target=tb_chacha_core $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : chacha
+      VLNV : secworks:crypto:chacha
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: chacha
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: build-openlane-sky130
+on: [push]
+
+jobs:
+  build-chacha-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : chacha
+      VLNV : secworks:crypto:chacha
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: chacha
+      - name: Checkout pdk
+        uses: actions/checkout@v2
+        with:
+          repository: olofk/pdklite
+          path: pdklite
+      - run: echo "PDK_ROOT=$GITHUB_WORKSPACE/pdklite" >> $GITHUB_ENV
+      - run: echo "EDALIZE_LAUNCHER=${GITHUB_WORKSPACE}/openlane_runner.py" >> $GITHUB_ENV
+      - run: pip3 install --user -e "git+https://github.com/olofk/edalize.git#egg=edalize"
+      - run: pip3 install fusesoc
+      - run: docker pull efabless/openlane:v0.12
+      - run: wget https://raw.githubusercontent.com/olofk/subservient/main/openlane_runner.py
+      - run: chmod +x openlane_runner.py
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV

--- a/README.md
+++ b/README.md
@@ -50,28 +50,40 @@ This core is supported by the
 [FuseSoC](https://github.com/olofk/fusesoc) core package manager and
 build system. Some quick  FuseSoC instructions:
 
-#install FuseSoC
+Install FuseSoC
+~~~
 pip install fusesoc
+~~~
 
-#Create and enter a new workspace
+Create and enter a new workspace
+~~~
 mkdir workspace && cd workspace
+~~~
 
-#Register aes as a library in the workspace
-fusesoc library add chacha /path/to/aes
-#...if repo is available locally or...
-#...to get the upstream repo
+Register chacha as a library in the workspace
+~~~
+fusesoc library add chacha /path/to/chacha
+~~~
+...if repo is available locally or...
+...to get the upstream repo
+~~~
 fusesoc library add chacha https://github.com/secworks/chacha
+~~~
 
-#Run tb_chacha testbench
+Run tb_chacha testbench
+~~~
 fusesoc run --target=tb_chacha secworks:crypto:chacha
+~~~
 
-#Run with modelsim instead of default tool (icarus)
+Run with modelsim instead of default tool (icarus)
+~~~
 fusesoc run --target=tb_chacha --tool=modelsim secworks:crypto:chacha
+~~~
 
-#List all targets
+List all targets
+~~~
 fusesoc core show secworks:crypto:aes
-
-
+~~~
 
 ## Implementation results##
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@ one round takes one cycle. The overhead latency cost when using the top
 level wrapper is three, which means that with eight rounds the total
 latency is 11 cycles. For ChaCha20 the latency is 23 cycles.
 
+## FuseSoC
+This core is supported by the
+[FuseSoC](https://github.com/olofk/fusesoc) core package manager and
+build system. Some quick  FuseSoC instructions:
+
+#install FuseSoC
+pip install fusesoc
+
+#Create and enter a new workspace
+mkdir workspace && cd workspace
+
+#Register aes as a library in the workspace
+fusesoc library add chacha /path/to/aes
+#...if repo is available locally or...
+#...to get the upstream repo
+fusesoc library add chacha https://github.com/secworks/chacha
+
+#Run tb_chacha testbench
+fusesoc run --target=tb_chacha secworks:crypto:chacha
+
+#Run with modelsim instead of default tool (icarus)
+fusesoc run --target=tb_chacha --tool=modelsim secworks:crypto:chacha
+
+#List all targets
+fusesoc core show secworks:crypto:aes
+
+
 
 ## Implementation results##
 

--- a/chacha.core
+++ b/chacha.core
@@ -25,6 +25,14 @@ targets:
     default:
         filesets: [rtl]
 
+    lint:
+        default_tool : verilator
+        filesets : [rtl]
+        tools:
+            verilator:
+                mode: lint-only
+        toplevel: chacha
+
     tb_chacha:
         default_tool: icarus
         filesets: [rtl, tb]

--- a/chacha.core
+++ b/chacha.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : secworks:crypto:chacha:1.0.0
+name : secworks:crypto:chacha:0
 description : Verilog 2001 implementation of the ChaCha stream cipher
 
 filesets:
@@ -14,7 +14,7 @@ filesets:
     tb:
         files:
             - src/tb/tb_chacha_core.v
-            - src/tb_chacha.v
+            - src/tb/tb_chacha.v
         file_type : verilogSource
 
     openlane:
@@ -25,8 +25,16 @@ targets:
     default:
         filesets: [rtl]
 
-    sim:
+    tb_chacha:
+        default_tool: icarus
         filesets: [rtl, tb]
+        toplevel: tb_chacha
+        parameters : [DEBUG]
+
+    tb_chacha_core:
+        default_tool: icarus
+        filesets: [rtl, tb]
+        toplevel: tb_chacha_core
 
     sky130:
         default_tool : openlane

--- a/chacha.core
+++ b/chacha.core
@@ -1,25 +1,41 @@
-CAPI=1
+CAPI=2:
 
-[main]
+name : secworks:crypto:chacha:1.0.0
+description : Verilog 2001 implementation of the ChaCha stream cipher
 
-name = ::chacha:0
-description = Verilog 2001 implementation of the ChaCha stream cipher
+filesets:
+    rtl:
+        files:
+            - src/rtl/chacha_qr.v
+            - src/rtl/chacha_core.v
+            - src/rtl/chacha.v
+        file_type : verilogSource
 
-[fileset rtl]
-files =
- src/rtl/chacha_qr.v
- src/rtl/chacha_core.v
- src/rtl/chacha.v
-file_type = verilogSource
+    tb:
+        files:
+            - src/tb/tb_chacha_core.v
+            - src/tb_chacha.v
+        file_type : verilogSource
 
-[fileset tb]
-files =
- src/tb/tb_chacha_core.v
- src/tb/tb_chacha.v
-file_type = verilogSource
-usage = sim
+    openlane:
+        files:
+            - src/data/openlane_params.tcl : {file_type : tclSource}
 
-[parameter DEBUG]
-datatype = int
-description = Enable debug printouts
-paramtype = vlogparam
+targets:
+    default:
+        filesets: [rtl]
+
+    sim:
+        filesets: [rtl, tb]
+
+    sky130:
+        default_tool : openlane
+        filesets : [rtl, openlane]
+        toplevel : chacha
+
+parameters:
+    DEBUG:
+        datatype : int
+        default : 0
+        paramtype : vlogparam
+        description : Enable debug printouts

--- a/src/data/openlane_params.tcl
+++ b/src/data/openlane_params.tcl
@@ -1,0 +1,8 @@
+# Variables for the Openlane flow, as taken from the example designs in the Openlane repository
+set ::env(CLOCK_PORT) "clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)
+set ::env(GLB_RT_ADJUSTMENT) 0.1
+set ::env(SYNTH_MAX_FANOUT) 6
+set ::env(CLOCK_PERIOD) "26.01"
+set ::env(FP_CORE_UTIL) 25
+set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]


### PR DESCRIPTION
Openlane support, CI and move to CAPI2 format. Core has targets for both testbenches, Verilator lint and Openlane builds, all of which are exercised in CI. Some Fusesoc instructions added in README.md.